### PR TITLE
Enable the convertion of one html file.

### DIFF
--- a/compile_exports.py
+++ b/compile_exports.py
@@ -33,7 +33,7 @@ def sanity_check():
     # check exports dir HTML presence
     print("Checking to see if there are files in exports dir...")
     files_in_exports_dir = glob.glob(os.path.join(EXPORTS_DIR, "*.html"))
-    if len(files_in_exports_dir) > 1:
+    if len(files_in_exports_dir) > 0:
         print(f"✅ Found {len(files_in_exports_dir)} HTML files to convert!")
         print("Files queued for inclusion:")
         for file in files_in_exports_dir:


### PR DESCRIPTION
The way the file works currently requires at least 2 .html files to be inputted (which can be annoying if you want a standalone piece to be converted to an easily modified LaTeX file).